### PR TITLE
chore: finish org rename ChabadLabs → chabad-commons

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 ChabadLabs
+Copyright (c) 2026 Chabad Commons
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/profile/README.md
+++ b/profile/README.md
@@ -21,10 +21,8 @@ Browse, install, and share community-built AI skills. Share your custom skills v
 
 The power of AI isn't just in the models — it's in how we build together.
 
-- [chabadlabs.ai](https://chabadlabs.ai) — Tools, workshops, and resources
-- [Request access](https://github.com/ChabadLabs/.github/issues/new?template=access-request.yml) — Get started with GabAI
-- [Join the Builders Chat](https://chabadlabs.ai) — Connect with other shluchim building with AI
+- [Request access](https://github.com/chabad-commons/.github/issues/new?template=access-request.yml) — Get started with GabAI
 
 ---
 
-*ChabadLabs is built by volunteers. AI is a tool that amplifies your work — not a replacement.*
+*Chabad Commons is built by volunteers. AI is a tool that amplifies your work — not a replacement.*


### PR DESCRIPTION
Completes the GitHub-org rename (**ChabadLabs → Chabad Commons**, slug `chabad-commons`) on top of the README branding edit already on `main`.

## Changes
- `profile/README.md` — access-request links → `github.com/chabad-commons/.github/...`; prose "ChabadLabs is built by volunteers" → "Chabad Commons".
- `profile/README.md` — **removed the `chabadlabs.ai` marketing-domain links** (the Tools/workshops and Builders Chat bullets).
- `LICENSE` — copyright holder → Chabad Commons.

No remaining `chabadlabs` references in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)